### PR TITLE
Recognize urls of the form git+https://github.com/tj/commander.js.git

### DIFF
--- a/giturlparse/parser.py
+++ b/giturlparse/parser.py
@@ -36,7 +36,7 @@ Parsed = collections.namedtuple('Parsed', [
 ])
 
 POSSIBLE_REGEXES = (
-    re.compile(r'^(?P<protocol>https?|git|ssh|rsync)\://'
+    re.compile(r'^((?P<protocol>https?|git|ssh|rsync)\+*)+\://'
                r'(?:(?P<user>.+)@)*'
                r'(?P<resource>[a-z0-9_.-]*)'
                r'[:/]*'


### PR DESCRIPTION
These patterns are returned by npm registry, eg, http://registry.npmjs.com/commander where the protocols are bundled together. It would be nice if giturlparse could add this patterns too.